### PR TITLE
Post data

### DIFF
--- a/src/CurlExecuter.php
+++ b/src/CurlExecuter.php
@@ -16,9 +16,9 @@ class CurlExecuter implements ExecuterIface
         $this->decoder = $decoder;
     }
 
-    public function doMethod($s)
+    public function doMethod($s, $headers = array())
     {
-        $headers = ["User-Agent: " . self::USER_AGENT];
+        $headers = array_merge(["User-Agent: " . self::USER_AGENT], $headers);
         curl_setopt($s, CURLOPT_HTTPHEADER, $headers);
         curl_setopt($s, CURLOPT_HEADER, TRUE);
         curl_setopt($s, CURLOPT_RETURNTRANSFER, TRUE);

--- a/src/CurlWrapper.php
+++ b/src/CurlWrapper.php
@@ -15,48 +15,61 @@ class CurlWrapper
         return new self(new CurlExecuter(new OutputDecoder()));
     }
 
+    private function initCurl($url, $queryString = NULL)
+    {
+        $s = curl_init();
+        curl_setopt($s, CURLOPT_URL, is_null($queryString) ? $url : $url . '?' . $queryString);
+
+        return $s;
+    }
+
     public function doGet($url, $queryString = NULL)
     {
-        $s = curl_init();
-        curl_setopt($s, CURLOPT_URL, is_null($queryString) ? $url : $url . '?' . $queryString);
-
+        $s = $this->initCurl($url, $queryString);
         return $this->executer->doMethod($s);
     }
 
-    public function doPost($url, $queryString = NULL)
+    private function addContent($s, $content, $contentType)
     {
-        $s = curl_init();
-        curl_setopt($s, CURLOPT_URL, $url);
+        $headers = array();
+
+        if (!empty($content))
+        {
+            curl_setopt($s, CURLOPT_POSTFIELDS, $content);
+            $jsonType = 'application/json';
+            if (strncmp($contentType, $jsonType, strlen($jsonType)) == 0) {
+                $headers[] = 'Content-Type: application/json';
+            }
+        }
+
+        return $headers;
+    }
+
+    public function doPost($url, $queryString = NULL, $content = NULL, $contentType = NULL)
+    {
+        $s = $this->initCurl($url, $queryString);
         curl_setopt($s, CURLOPT_POST, TRUE);
-        if (!is_null($queryString)) {
-            curl_setopt($s, CURLOPT_POSTFIELDS, parse_str($queryString));
-        }
+        $headers = $this->addContent($s, $content, $contentType);
 
-        return$this->executer->doMethod($s);
+        return$this->executer->doMethod($s, $headers);
     }
 
-    public function doPut($url, $queryString = NULL)
+    public function doPut($url, $queryString = NULL, $content = NULL, $contentType = NULL)
     {
-        $s = curl_init();
-        curl_setopt($s, CURLOPT_URL, $url);
+        $s = $this->initCurl($url, $queryString);
         curl_setopt($s, CURLOPT_CUSTOMREQUEST, 'PUT');
-        if (!is_null($queryString)) {
-            curl_setopt($s, CURLOPT_POSTFIELDS, parse_str($queryString));
-        }
+        $headers = $this->addContent($s, $content, $contentType);
 
-        return $this->executer->doMethod($s);
+        return $this->executer->doMethod($s, $headers);
     }
 
-    public function doDelete($url, $queryString = NULL)
+    public function doDelete($url, $queryString = NULL, $content = NULL, $contentType = NULL)
     {
-        $s = curl_init();
-        curl_setopt($s, CURLOPT_URL, is_null($queryString) ? $url : $url . '?' . $queryString);
+        $s = $this->initCurl($url, $queryString);
         curl_setopt($s, CURLOPT_CUSTOMREQUEST, 'DELETE');
-        if (!is_null($queryString)) {
-            curl_setopt($s, CURLOPT_POSTFIELDS, parse_str($queryString));
-        }
+        $headers = $this->addContent($s, $content, $contentType);
 
-        return $this->executer->doMethod($s);
+        return $this->executer->doMethod($s, $headers);
     }
 
     public function getStatus()

--- a/src/ExecuterIface.php
+++ b/src/ExecuterIface.php
@@ -6,7 +6,7 @@ interface ExecuterIface
 {
     public function __construct(DecoderIface $decoder);
 
-    public function doMethod($s);
+    public function doMethod($s, $headers = array());
 
     public function getStatus();
 

--- a/src/RestProxy.php
+++ b/src/RestProxy.php
@@ -62,8 +62,10 @@ class RestProxy
     {
         $queryString = $this->request->getQueryString();
         $action      = $this->getActionName($this->request->getMethod());
+        $content     = $this->request->getContent();
+        $contentType = $this->request->headers->get('content-type');
 
-        $this->content = $this->curl->$action($url, $queryString);
+        $this->content = $this->curl->$action($url, $queryString, $content, $contentType);
         $this->headers = $this->curl->getHeaders();
     }
 

--- a/src/RestProxy.php
+++ b/src/RestProxy.php
@@ -63,7 +63,8 @@ class RestProxy
         $queryString = $this->request->getQueryString();
         $action      = $this->getActionName($this->request->getMethod());
         $content     = $this->request->getContent();
-        $contentType = $this->request->headers->get('content-type');
+        $headers     = $this->request->headers;
+        $contentType = is_null($headers) ? NULL : $headers->get('content-type');
 
         $this->content = $this->curl->$action($url, $queryString, $content, $contentType);
         $this->headers = $this->curl->getHeaders();


### PR DESCRIPTION
There are some problems when the proxy is used to forward POST, PUT and DELETE data. First of all, converting query string to the content is not right, as it might cause problems in some remote scripts that expect the data to be at the original place. Second of all, if there is a content sent in the original request, the content is lost in the forwarded request. This proposed pull request fixes both these issues, plus it adds support for json content.