### PR TITLE
Improvements of response HTTP status handling

### DIFF
--- a/src/CurlExecuter.php
+++ b/src/CurlExecuter.php
@@ -4,7 +4,7 @@ namespace RestProxy;
 
 class CurlExecuter implements ExecuterIface
 {
-    const HTTP_OK = 200;
+    const HTTP_SUCCESS = 2;
     const USER_AGENT = 'gonzalo123/rest-proxy';
 
     private $responseHeaders = [];
@@ -28,11 +28,16 @@ class CurlExecuter implements ExecuterIface
         curl_close($s);
 
         list($this->responseHeaders, $content) = $this->decoder->decodeOutput($out);
-        if ($this->status != self::HTTP_OK) {
+        if (!$this->isSuccessful($this->status)) {
             throw new \Exception("http error: {$this->status}", $this->status);
         }
 
         return $content;
+    }
+
+    private function isSuccessful($code) {
+        $codeFamily = (int)($code/100);
+        return $codeFamily == self::HTTP_SUCCESS;
     }
 
     public function getStatus()

--- a/src/RestProxy.php
+++ b/src/RestProxy.php
@@ -11,6 +11,7 @@ class RestProxy
 
     private $content;
     private $headers;
+    private $status;
 
     const GET = "GET";
     const POST = "POST";
@@ -58,6 +59,11 @@ class RestProxy
         return $this->content;
     }
 
+    public function getStatus()
+    {
+        return $this->status;
+    }
+
     private function dispatch($url)
     {
         $queryString = $this->request->getQueryString();
@@ -68,6 +74,7 @@ class RestProxy
 
         $this->content = $this->curl->$action($url, $queryString, $content, $contentType);
         $this->headers = $this->curl->getHeaders();
+        $this->status  = $this->curl->getStatus();
     }
 
     private function getActionName($requestMethod)


### PR DESCRIPTION
This time I'd like to propose a few improvements of the way how HTTP status of the reponse is handled. The first patch extends the set of accepted status codes to all 2xx codes, as they all signal success of the operation. I have not implemented any finer granularity but I am absolutely willing to do so if you think it's worth it.

The second patch enables access to the response status code the same way headers are accessed.

Both these patches are required for the proxy to be usable in real REST environment - for example the DELETE operation usually induces 204 status code if successful. Therefore I'd recommend backporting both patches to the master branch as well.
